### PR TITLE
rename arm image

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker Images
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           docker push ${{ env.IMAGE_NAME }}
           docker push ${{ env.IMAGE_NAME_ARM }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -38,15 +38,8 @@ jobs:
           echo "Image name: ${{ env.IMAGE_NAME_ARM }}"
           docker buildx build --cache-to type=local,dest=${{ runner.workspace }}/docker-layers --cache-from type=local,src=${{ runner.workspace }}/docker-layers -t ${{ env.IMAGE_NAME_ARM }} -f core/Dockerfile.arm --load .
 
-      # - name: Login to GitHub Container Registry
-      #   uses: docker/login-action@v2
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Push Docker Images
-        # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
           docker push ${{ env.IMAGE_NAME }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,7 +8,7 @@ on:
 name: workflow
 env:
   IMAGE_NAME: ghcr.io/shedrachokonofua/lute-v4:${{ github.sha }}
-  IMAGE_NAME_ARM: ghcr.io/shedrachokonofua/lute-v4:${{ github.sha }}-arm
+  IMAGE_NAME_ARM: ghcr.io/shedrachokonofua/lute-v4-arm:${{ github.sha }}
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -38,15 +38,16 @@ jobs:
           echo "Image name: ${{ env.IMAGE_NAME_ARM }}"
           docker buildx build --cache-to type=local,dest=${{ runner.workspace }}/docker-layers --cache-from type=local,src=${{ runner.workspace }}/docker-layers -t ${{ env.IMAGE_NAME_ARM }} -f core/Dockerfile.arm --load .
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v2
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker Images
         # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
+          docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
           docker push ${{ env.IMAGE_NAME }}
           docker push ${{ env.IMAGE_NAME_ARM }}


### PR DESCRIPTION
the workflow currently only works for the x86 image and gets permission denied when pushing the arm image. prior to failing the push, there were some `Layer already exists` logs which may indicate some conflicts when pushing the image. in order to decouple things, i'm making a new image name for the arm image rather than using tags to identify.

this change also removes the dependency for authorizing to docker and does it manually.